### PR TITLE
branch name changed from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ heroku run python manage.py migrate
 ```shell
 git add .
 git commit -m "edit"
-git push heroku master
+git push heroku main
 ```


### PR DESCRIPTION
The default branch name in GitHub is changed from master to main, that's why I have changed the code mentioned from branch name "master" to "main".